### PR TITLE
fix: lucky pick is from current tables

### DIFF
--- a/index.html
+++ b/index.html
@@ -225,7 +225,23 @@
     }
 
     function gotoLucky() {
-        const luckyID = "ramen-info-item-" + Math.floor(Math.random() * awesome_list.length);
+        for (const item of document.querySelectorAll('.is-indicated')) {
+            item.classList.remove('is-indicated');
+        }
+
+        const candidates = [];
+        for (const index of awesome_list.keys()) {
+            if (!document.querySelector(`#ramen-info-item-${index}`).classList.contains('u-hidden')) {
+                candidates.push(index);
+            }
+        }
+
+        if (candidates.length === 0) {
+            history.pushState(null, document.title, window.location.pathname + window.location.search);
+            return;
+        }
+
+        const luckyID = "ramen-info-item-" + candidates[Math.floor(Math.random() * candidates.length)];
         document.getElementById(luckyID).classList.add("is-indicated");
         location.hash = "#" + luckyID;
     }


### PR DESCRIPTION
![fix-lucky-pick](https://github.com/ss8651twtw/rameninfo/assets/8157236/4af19356-1948-4ca9-959c-a133143ae0c0)

- 當 table 沒有店家時，按 lucky pick 按鈕會清掉 `#`

Closes #3